### PR TITLE
feat: 페이지네이션 기능 구현

### DIFF
--- a/triptalkie/src/main/java/com/walkietalkie/triptalkie/controller/TravelReviewController.java
+++ b/triptalkie/src/main/java/com/walkietalkie/triptalkie/controller/TravelReviewController.java
@@ -5,7 +5,6 @@ import java.util.Map;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -16,6 +15,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.walkietalkie.triptalkie.domain.City;
+import com.walkietalkie.triptalkie.domain.CommonPage;
 import com.walkietalkie.triptalkie.domain.TravelReview;
 import com.walkietalkie.triptalkie.service.CityService;
 import com.walkietalkie.triptalkie.service.TravelReviewService;
@@ -34,13 +34,19 @@ public class TravelReviewController {
 		this.travelReviewService = travelReviewService;
 		this.cityService = cityService;
 	}
-
+	
 	@GetMapping("/findTravelreviewAllList")
-	public String findTravelreviewAllList (Model model){
-	    List<Map<String, Object>> reviewList = travelReviewService.findTravelreviewAllList();
-	    model.addAttribute("reviewList", reviewList);
-	    
-	    return "pages/travel-review/findTravelreviewAllList";
+	public String findTravelreviewAllList (@RequestParam(defaultValue = "1") int page, 
+	                                       @RequestParam(defaultValue = "5") int size, 
+	                                       Model model){
+		// 서비스에서 바로 CommonPage 객체 생성
+		CommonPage<Map<String, Object>> pageData = travelReviewService.findTravelreviewPage(page, size);
+
+		// 모델에 데이터 넣기
+		model.addAttribute("reviewList", pageData.getContent()); // 실제 데이터 리스트
+		model.addAttribute("pageData", pageData); // 페이징 정보 전체
+
+		return "pages/travel-review/findTravelreviewAllList";
 	}
 	
 	@GetMapping("/detail-review/{idx}")

--- a/triptalkie/src/main/java/com/walkietalkie/triptalkie/domain/CommonPage.java
+++ b/triptalkie/src/main/java/com/walkietalkie/triptalkie/domain/CommonPage.java
@@ -1,0 +1,75 @@
+package com.walkietalkie.triptalkie.domain;
+
+import java.util.List;
+
+public class CommonPage<T> {
+	private List<T> content;
+	private int size;	// 한 페이지에 보여줄 아이템 수
+	private int currentPage;
+	private int totalPage;
+	private int startPage;
+	private int endPage;
+	
+	public CommonPage() {
+		super();
+	}
+
+	public CommonPage(List<T> content, int size, int currentPage, int totalPage, int startPage, int endPage) {
+		super();
+		this.content = content;
+		this.size = size;
+		this.currentPage = currentPage;
+		this.totalPage = totalPage;
+		this.startPage = startPage;
+		this.endPage = endPage;
+	}
+
+	public List<T> getContent() {
+		return content;
+	}
+
+	public void setContent(List<T> content) {
+		this.content = content;
+	}
+
+	public int getSize() {
+		return size;
+	}
+
+	public void setSize(int size) {
+		this.size = size;
+	}
+
+	public int getCurrentPage() {
+		return currentPage;
+	}
+
+	public void setCurrentPage(int currentPage) {
+		this.currentPage = currentPage;
+	}
+
+	public int getTotalPage() {
+		return totalPage;
+	}
+
+	public void setTotalPage(int totalPage) {
+		this.totalPage = totalPage;
+	}
+
+	public int getStartPage() {
+		return startPage;
+	}
+
+	public void setStartPage(int startPage) {
+		this.startPage = startPage;
+	}
+
+	public int getEndPage() {
+		return endPage;
+	}
+
+	public void setEndPage(int endPage) {
+		this.endPage = endPage;
+	}
+
+}

--- a/triptalkie/src/main/java/com/walkietalkie/triptalkie/mapper/TravelReviewMapper.java
+++ b/triptalkie/src/main/java/com/walkietalkie/triptalkie/mapper/TravelReviewMapper.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import com.walkietalkie.triptalkie.domain.TravelReview;
 
@@ -19,5 +20,9 @@ public interface TravelReviewMapper {
 	Long registerTravelreview(TravelReview travelreview);
 
 	void updateTravelreviewByIdxAndMemberId(TravelReview travelreview);
+	
+	int findTravelreviewAllCount();
+
+	List<Map<String, Object>> findPaged(@Param("size") int size, @Param("startRow") int startRow);
 
 }

--- a/triptalkie/src/main/java/com/walkietalkie/triptalkie/service/TravelReviewService.java
+++ b/triptalkie/src/main/java/com/walkietalkie/triptalkie/service/TravelReviewService.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.walkietalkie.triptalkie.domain.CommonPage;
 import com.walkietalkie.triptalkie.domain.TravelReview;
 import com.walkietalkie.triptalkie.mapper.TravelReviewMapper;
 
@@ -19,7 +20,7 @@ public class TravelReviewService {
 	}
 
 	/*
-	 *  여행 리뷰 리스트 조회
+	 * 여행 리뷰 리스트 조회
 	 */
 	@Transactional(readOnly = true)
 	public List<Map<String, Object>> findTravelreviewAllList() {
@@ -41,9 +42,26 @@ public class TravelReviewService {
 
 	public void updateTravelreviewByIdxAndMemberId(TravelReview travelReview) {
 		travelReviewMapper.updateTravelreviewByIdxAndMemberId(travelReview);
-		
+
 	}
-	
-	
+
+	/*
+	 * 페이지네이션(Map 리스트 기준)
+	 */
+	public CommonPage<Map<String, Object>> findTravelreviewPage(int page, int size) {
+		int totalCount = travelReviewMapper.findTravelreviewAllCount();
+		int totalPages = (int) Math.ceil((double) totalCount / size);
+
+		int startRow = (page - 1) * size;
+
+		// Map 기반으로 페이징 쿼리 호출
+		List<Map<String, Object>> list = travelReviewMapper.findPaged(size, startRow);
+
+		int pageBlock = 5; // 한 화면에 표시할 페이지 수
+		int startPage = ((page - 1) / pageBlock) * pageBlock + 1;
+		int endPage = Math.min(startPage + pageBlock - 1, totalPages);
+
+		return new CommonPage<>(list, size, page, totalPages, startPage, endPage);
+	}
 
 }

--- a/triptalkie/src/main/resources/com/walkietalkie/triptalkie/mapper/TravelReviewMapper.xml
+++ b/triptalkie/src/main/resources/com/walkietalkie/triptalkie/mapper/TravelReviewMapper.xml
@@ -1,38 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.walkietalkie.triptalkie.mapper.TravelReviewMapper">
-	<select id="findTravelreviewAllList" resultType="map">
+<mapper
+	namespace="com.walkietalkie.triptalkie.mapper.TravelReviewMapper">
+	<!-- 전체 게시글 수 조회 -->
+	<select id="findTravelreviewAllCount" resultType="int">
+		SELECT COUNT(*)
+		FROM travelreview
+	</select>
+
+	<!-- 페이징 처리된 게시글 조회 -->
+	<select id="findPaged" resultType="map" parameterType="map">
 		SELECT
 		t.idx,
 		t.title,
 		t.content,
-		t.created_at AS
-		createdAt,
+		t.created_at AS createdAt,
 		t.updated_at AS updatedAt,
 		t.mateuse,
 		t.concepttype AS conceptType,
 		t.matetype AS mateType,
 		t.city_id AS cityId,
 		c.name AS cityName,
-		t.member_id AS
-		memberId,
+		t.member_id AS memberId,
 		m.nickname AS memberNickname
 		FROM travelreview t
-		LEFT JOIN
-		member m ON t.member_id
-		= m.id
+		LEFT JOIN member m ON t.member_id = m.id
 		LEFT JOIN city c ON t.city_id = c.id
-		ORDER BY t.idx DESC;
+		ORDER BY t.idx DESC
+		LIMIT #{size} OFFSET #{startRow}
+	</select>
+
+	<select id="findTravelreviewAllList" resultType="map">
+		SELECT
+		t.idx,
+		t.title,
+		t.content,
+		t.created_at AS createdAt,
+		t.updated_at AS updatedAt,
+		t.mateuse,
+		t.concepttype AS conceptType,
+		t.matetype AS mateType,
+		t.city_id AS cityId,
+		c.name AS cityName,
+		t.member_id AS memberId,
+		m.nickname AS memberNickname
+		FROM travelreview t
+		LEFT JOIN member m ON t.member_id = m.id
+		LEFT JOIN city c ON t.city_id = c.id
+		ORDER BY t.idx DESC
 	</select>
 
 	<insert id="registerTravelreview"
 		parameterType="com.walkietalkie.triptalkie.domain.TravelReview"
 		useGeneratedKeys="true" keyProperty="idx">
 		INSERT INTO travelreview
-		(title, created_at, mateuse, concepttype, matetype, content, city_id,
-		member_id)
-		VALUES (#{title}, NOW(), #{mateUse}, #{conceptType}, #{mateType},
-		#{content}, #{cityId}, #{memberId})
+		(title, created_at, mateuse, concepttype, matetype, content, city_id, member_id)
+		VALUES (#{title}, NOW(), #{mateUse}, #{conceptType}, #{mateType}, #{content}, #{cityId}, #{memberId})
 
 	</insert>
 
@@ -52,19 +75,18 @@
 		t.member_id AS memberId,
 		m.nickname AS memberNickname
 		FROM travelreview t
-		LEFT JOIN member m ON
-		t.member_id
-		= m.id
+		LEFT JOIN member m ON t.member_id = m.id
 		LEFT JOIN city c ON t.city_id = c.id
-		WHERE idx =
-		#{idx};
+		WHERE idx = #{idx};
 	</select>
 
-	<update id="updateTravelreviewByIdxAndMemberId" parameterType="com.walkietalkie.triptalkie.domain.TravelReview">
+	<update id="updateTravelreviewByIdxAndMemberId"
+		parameterType="com.walkietalkie.triptalkie.domain.TravelReview">
 		UPDATE travelreview
 		SET
 		title = #{title},
-		content = #{content},
+		content =
+		#{content},
 		mateuse = #{mateUse},
 		concepttype = #{conceptType},
 		matetype = #{mateType},
@@ -75,8 +97,7 @@
 	</update>
 
 	<delete id="deleteTravelreviewByIdx" parameterType="Long">
-		DELETE FROM
-		travelreview
+		DELETE FROM travelreview
 		WHERE idx = #{idx}
 	</delete>
 </mapper>


### PR DESCRIPTION
**개요**
게시글 리스트에 필요한 페이지네이션 기능 구현
     
**구현 내용**
- 게시글 리스트에 필요한 페이지네이션 기능을 구현하기 위해 공통 도메인인 CommonPage<T>를 생성
- 해당 게시글의 controller, service, mapper에 메서드 및 쿼리 구현
- 게시글 페이지에서 하단의 페이지네이션 생성, 클릭 시 다음 페이지로 이동, 한 페이지당 총 5개 출력되도록 controller 구현
    
**테스트 방법**
- 프로젝트 실행 시 확인 가능