### PR TITLE
fix : 여행 정보 사진 보여줄 때 비율 유지하면서 꽉 차게 수정

### DIFF
--- a/triptalkie/src/main/resources/static/css/travel-info.css
+++ b/triptalkie/src/main/resources/static/css/travel-info.css
@@ -1,26 +1,26 @@
 /* travel-info.css */
-/* travel-info 페이지 전용 이미지 박스 (16:9 비율) */
+/* travel-info 페이지 전용 이미지 박스 (4:3 비율 고정) */
 .travel-info-page .info-imagebox {
-  width: 100%;             /* 부모 폭에 맞춤 */
+  width: 100%;
   max-width: 100%;
   height: 0;
-  padding-top: 56.25%;
+  padding-top: 75%;        /* 4:3 비율 유지 */
   overflow: hidden;
   position: relative;
+  background-color: #fff;
+  border-radius: 8px;
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: #f0f0f0;
-  border-radius: 8px;
 }
 
-/* 이미지 */
+/* 이미지: 잘리지 않고 전부 보임 */
 .travel-info-page .info-imagebox .info-image {
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-  object-fit: contain;
+  object-fit: contain;     /* 전체 보이되 비율 유지 */
   display: block;
 }


### PR DESCRIPTION
**개요**
fix : 여행 정보 사진 보여줄 때 비율 유지하면서 꽉 차게 수정
     
**구현 내용**
여행 정보 상세 페이지에서 사진 보여 줄 때 비율이 유지되면서 꽉차게 나오게 조정
    
**테스트 방법**
-